### PR TITLE
Epsilon added to terminal group of Grammar Generation with patterns

### DIFF
--- a/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
+++ b/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
@@ -89,7 +89,7 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 							rightSideCompounds[i] = nonTerminals.get((index+1) % nonTerminals.size());
 					}
 			}
-			String rightSide = String.join(" ",rightSideCompounds);
+			String rightSide = String.join("",rightSideCompounds);
 			generatedProductions.add(new GrammarProduction(nonTerminal, rightSide));
 		}
 		return generatedProductions.stream().distinct().toList();
@@ -188,7 +188,7 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 				rightSideCompounds[i] = terminals.get(index);
 			}
 		}
-		String rightSide = String.join(" ",rightSideCompounds);
+		String rightSide = String.join("",rightSideCompounds);
 
 		return new GrammarProduction(leftSide, rightSide);
 	}
@@ -211,7 +211,7 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 				}
 			}
 		}
-		String rightSide = String.join(" ",rightSideCompounds);
+		String rightSide = String.join("",rightSideCompounds);
 
 		return new GrammarProduction(leftSideNonTerminal, rightSide);
 	}

--- a/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
+++ b/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
@@ -30,6 +30,8 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 		startSymbol = nonTerminals.iterator().next();
 		productions = generateProductions();
 
+		addEpsilonToTerminals();
+
 		return new Grammar(terminals.toArray(new String[0]), nonTerminals.toArray(new String[0]),
 				productions.toArray(new GrammarProduction[0]), startSymbol);
 	}
@@ -121,7 +123,7 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 		List<String> tmpTerminals = new ArrayList<>(terminals);
 		for (String str: terminals) {
 			for (GrammarProduction gr : resultProductions) {
-				if (!gr.rightSide().contains("epsilon") && gr.rightSide().contains(str)){
+				if (!gr.rightSide().contains("ε") && gr.rightSide().contains(str)){
 					tmpTerminals.remove(str);
 				}
 			}
@@ -212,6 +214,12 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 		String rightSide = String.join(" ",rightSideCompounds);
 
 		return new GrammarProduction(leftSideNonTerminal, rightSide);
+	}
+
+	private void addEpsilonToTerminals(){
+		if (productions.stream().anyMatch(p -> p.rightSide().contains("ε"))){
+			terminals.add("ε");
+		}
 	}
 
 }

--- a/src/main/java/de/dhbw/karlsruhe/models/ProductionRightSide.java
+++ b/src/main/java/de/dhbw/karlsruhe/models/ProductionRightSide.java
@@ -9,7 +9,7 @@ public enum ProductionRightSide {
     p2("N", false),
     p3("t N", false),
     p4("t t N", false),
-    p5("epsilon", true),
+    p5("ε", true),
     p6("N t", false),
     p7("N t t", false),
     p8("t N t", false),


### PR DESCRIPTION
Wenn Epsilon in den Produktionen vorkommt, wird es zu der Menge der Terminalsymbole hinzugefügt.

Epsilon in der Grammatikgenerierung mit Mustern durch ε ersetzt.