### PR TITLE
Word generation with Read and Action Limit

### DIFF
--- a/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
+++ b/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
@@ -6,6 +6,7 @@ import de.dhbw.karlsruhe.controller.dto.WordReadActionLimitationDto;
 import de.dhbw.karlsruhe.grammar.generation.GrammarGeneration;
 import de.dhbw.karlsruhe.grammar.generation.GrammarPatternProductionsGeneration;
 import de.dhbw.karlsruhe.models.Grammar;
+import de.dhbw.karlsruhe.word.generation.ParserLimitation;
 import de.dhbw.karlsruhe.word.generation.WordGeneration;
 import de.dhbw.karlsruhe.word.generation.WordLimitationsNotFulfillableException;
 import org.springframework.http.HttpStatus;
@@ -68,8 +69,8 @@ public class WordGenerationController {
     WordGeneration wordGeneration = new WordGeneration(wordReadActionLimitationDto.getGrammar());
 
     try {
-      return new ResponseEntity<>(wordGeneration.generateWordWithParserLimitations(
-              wordReadActionLimitationDto.getMaxReadCount(), wordReadActionLimitationDto.getMaxActionCount()
+      return new ResponseEntity<>(wordGeneration.generateWord(
+              new ParserLimitation(wordReadActionLimitationDto.getMaxReadCount(), wordReadActionLimitationDto.getMaxActionCount())
       ), HttpStatus.OK);
     } catch (WordLimitationsNotFulfillableException e) {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
+++ b/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
@@ -63,7 +63,7 @@ public class WordGenerationController {
     }
   }
 
-  @PostMapping("/api/get/word/ReadAction-Limitation")
+  @PostMapping("/api/get/word/Read-Action-Limitation")
   ResponseEntity<String> getWordWithLimitation(@RequestBody WordReadActionLimitationDto wordReadActionLimitationDto) {
     wordReadActionLimitationDto.getGrammar().splitOrGrammarsIntoSingleRules();
     WordGeneration wordGeneration = new WordGeneration(wordReadActionLimitationDto.getGrammar());

--- a/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
+++ b/src/main/java/de/dhbw/karlsruhe/controller/WordGenerationController.java
@@ -2,6 +2,7 @@ package de.dhbw.karlsruhe.controller;
 
 import de.dhbw.karlsruhe.controller.dto.WordGenerationCharacterDto;
 import de.dhbw.karlsruhe.controller.dto.WordGenerationProductionDto;
+import de.dhbw.karlsruhe.controller.dto.WordReadActionLimitationDto;
 import de.dhbw.karlsruhe.grammar.generation.GrammarGeneration;
 import de.dhbw.karlsruhe.grammar.generation.GrammarPatternProductionsGeneration;
 import de.dhbw.karlsruhe.models.Grammar;
@@ -55,6 +56,20 @@ public class WordGenerationController {
     try {
       return new ResponseEntity<>(wordGeneration.generateWord(
           wordGenerationProductionDto.getMaxProductionCount()
+      ), HttpStatus.OK);
+    } catch (WordLimitationsNotFulfillableException e) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  @PostMapping("/api/get/word/ReadAction-Limitation")
+  ResponseEntity<String> getWordWithLimitation(@RequestBody WordReadActionLimitationDto wordReadActionLimitationDto) {
+    wordReadActionLimitationDto.getGrammar().splitOrGrammarsIntoSingleRules();
+    WordGeneration wordGeneration = new WordGeneration(wordReadActionLimitationDto.getGrammar());
+
+    try {
+      return new ResponseEntity<>(wordGeneration.generateWordWithParserLimitations(
+              wordReadActionLimitationDto.getMaxReadCount(), wordReadActionLimitationDto.getMaxActionCount()
       ), HttpStatus.OK);
     } catch (WordLimitationsNotFulfillableException e) {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/src/main/java/de/dhbw/karlsruhe/controller/dto/WordReadActionLimitationDto.java
+++ b/src/main/java/de/dhbw/karlsruhe/controller/dto/WordReadActionLimitationDto.java
@@ -1,0 +1,26 @@
+package de.dhbw.karlsruhe.controller.dto;
+
+import de.dhbw.karlsruhe.models.Grammar;
+
+public class WordReadActionLimitationDto {
+
+    private Grammar grammar;
+    private int maxReadCount;
+    private int maxActionCount;
+
+    public WordReadActionLimitationDto() {
+
+    }
+
+    public Grammar getGrammar() {
+        return grammar;
+    }
+
+    public int getMaxReadCount() {
+        return maxReadCount;
+    }
+
+    public int getMaxActionCount() {
+        return maxActionCount;
+    }
+}

--- a/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
+++ b/src/main/java/de/dhbw/karlsruhe/grammar/generation/GrammarPatternProductionsGeneration.java
@@ -111,6 +111,7 @@ public class GrammarPatternProductionsGeneration extends GrammarGeneration{
 					GrammarProduction tmpProduction = generateSingleProduction(pSet.getRandomRightSideNonTerminal(), grammarProductions.get(i).leftSide());
 					grammarProductions.add(tmpProduction);
 					pSet.addProduction(tmpProduction);
+					pSet.addProduction(grammarProductions.get(i));
 				}
 			}
 			grammarProductions = new ArrayList<>(new HashSet<>(grammarProductions));

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/ParserLimitation.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/ParserLimitation.java
@@ -1,11 +1,19 @@
 package de.dhbw.karlsruhe.word.generation;
 
 public class ParserLimitation {
-    int maxReadCount;
-    int maxActionCount;
+    private int maxReadCount;
+    private int maxActionCount;
 
     public ParserLimitation(int maxReadCount, int maxActionCount) {
         this.maxReadCount = maxReadCount;
         this.maxActionCount = maxActionCount;
+    }
+
+    public int getMaxReadCount() {
+        return maxReadCount;
+    }
+
+    public int getMaxActionCount() {
+        return maxActionCount;
     }
 }

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/ParserLimitation.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/ParserLimitation.java
@@ -1,0 +1,11 @@
+package de.dhbw.karlsruhe.word.generation;
+
+public class ParserLimitation {
+    int maxReadCount;
+    int maxActionCount;
+
+    public ParserLimitation(int maxReadCount, int maxActionCount) {
+        this.maxReadCount = maxReadCount;
+        this.maxActionCount = maxActionCount;
+    }
+}

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/ToManyProductionsException.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/ToManyProductionsException.java
@@ -7,6 +7,6 @@ public class ToManyProductionsException extends Exception{
     }
 
     ToManyProductionsException(int readLimit, int actionLimit){
-        super("Genutzte Produktionen überschreiten das Limit der Leseproduktionen von"+ readLimit+" oder der Aktionsproduktionen von "+actionLimit+"!");
+        super("Genutzte Produktionen überschreiten das Limit der Leseproduktionen von "+ readLimit+" oder der Aktionsproduktionen von "+actionLimit+"!");
     }
 }

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/ToManyProductionsException.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/ToManyProductionsException.java
@@ -5,4 +5,8 @@ public class ToManyProductionsException extends Exception{
     ToManyProductionsException(int productionLimit){
         super("Genutzte Produktionen überschreiten das Limit von "+ productionLimit+" Produktionen!");
     }
+
+    ToManyProductionsException(int readLimit, int actionLimit){
+        super("Genutzte Produktionen überschreiten das Limit der Leseproduktionen von"+ readLimit+" oder der Aktionsproduktionen von "+actionLimit+"!");
+    }
 }

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/WordGeneration.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/WordGeneration.java
@@ -33,8 +33,8 @@ public class WordGeneration {
 
     public String generateWord(ParserLimitation parserLimitation, int minWordLength) throws WordLimitationsNotFulfillableException{
 
-        this.maxReadCount = parserLimitation.maxReadCount;
-        this.maxActionCount = parserLimitation.maxActionCount;
+        this.maxReadCount = parserLimitation.getMaxReadCount();
+        this.maxActionCount = parserLimitation.getMaxActionCount();
         List<GrammarProduction> startProductions = getPotentialStartProductions();
 
         int countTries = 0;
@@ -63,7 +63,7 @@ public class WordGeneration {
 
         if (productionService.isEndProduction(production)) {
             currentReadCount += production.rightSide().length();
-            if (currentReadCount > maxReadCount || currentActionCount > maxActionCount)
+            if (currentReadCount > maxReadCount)
                 throw new ToManyProductionsException(maxReadCount,maxActionCount);
             return production.rightSide();
         }
@@ -73,14 +73,14 @@ public class WordGeneration {
             char currentSymbol = production.rightSide().charAt(i);
             if (Arrays.stream(grammar.getTerminals()).toList().contains(String.valueOf(currentSymbol))){
                 currentReadCount++;
-                if (currentReadCount > maxReadCount || currentActionCount > maxActionCount)
+                if (currentReadCount > maxReadCount)
                     throw new ToManyProductionsException(maxReadCount,maxActionCount);
                 wordFragment.append(currentSymbol);
             }
             else {
                 List<GrammarProduction> potentialProduction = getPotentialProductions(String.valueOf(currentSymbol));
                 currentActionCount++;
-                if (currentReadCount > maxReadCount || currentActionCount > maxActionCount)
+                if (currentActionCount > maxActionCount)
                     throw new ToManyProductionsException(maxReadCount,maxActionCount);
                 wordFragment.append(traverseProductionsWithParserLimitations(potentialProduction.get(rand.nextInt(potentialProduction.size()))));
             }

--- a/src/main/java/de/dhbw/karlsruhe/word/generation/WordGeneration.java
+++ b/src/main/java/de/dhbw/karlsruhe/word/generation/WordGeneration.java
@@ -4,6 +4,7 @@ import de.dhbw.karlsruhe.models.Grammar;
 import de.dhbw.karlsruhe.models.GrammarProduction;
 import de.dhbw.karlsruhe.services.ProductionService;
 
+import javax.swing.text.html.parser.Parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,14 +27,14 @@ public class WordGeneration {
         this.grammar = grammar;
     }
 
-    public String generateWordWithParserLimitations(int maxReadCount, int maxActionCount) throws WordLimitationsNotFulfillableException {
-        return generateWordWithParserLimitations(maxReadCount,maxActionCount,1,100);
+    public String generateWord(ParserLimitation parserLimitation) throws WordLimitationsNotFulfillableException {
+        return generateWord(parserLimitation,1);
     }
 
-    public String generateWordWithParserLimitations(int maxReadCount, int maxActionCount, int minWordLength, int maxWordLength) throws WordLimitationsNotFulfillableException{
+    public String generateWord(ParserLimitation parserLimitation, int minWordLength) throws WordLimitationsNotFulfillableException{
 
-        this.maxReadCount = maxReadCount;
-        this.maxActionCount = maxActionCount;
+        this.maxReadCount = parserLimitation.maxReadCount;
+        this.maxActionCount = parserLimitation.maxActionCount;
         List<GrammarProduction> startProductions = getPotentialStartProductions();
 
         int countTries = 0;
@@ -54,7 +55,7 @@ public class WordGeneration {
             } catch (ToManyProductionsException e){
                 word="";
             }
-        } while (maxWordLength< word.length() || word.length() < minWordLength);
+        } while (word.length() < minWordLength);
         return word;
     }
 

--- a/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
@@ -86,7 +86,7 @@ class WordGenerationTest {
     }
 
     @Test
-    void ReadCountTest() {
+    void readCountTest() {
         for (int i = 0; i < 100; i++) {
             GrammarGeneration grammarGeneration = getGrammarGeneration();
             Grammar grammar = grammarGeneration.generateGrammar();

--- a/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
@@ -85,6 +85,22 @@ class WordGenerationTest {
         }
     }
 
+    @Test
+    void ReadCountTest() {
+        for (int i = 0; i < 100; i++) {
+            GrammarGeneration grammarGeneration = getGrammarGeneration();
+            Grammar grammar = grammarGeneration.generateGrammar();
+            WordGeneration wordGeneration = new WordGeneration(grammar);
+            String word;
+            try {
+                word = wordGeneration.generateWordWithParserLimitations(3,10);
+                assertTrue(word.length() <= 3);
+            } catch (WordLimitationsNotFulfillableException e) {
+                // Skip not fitting grammars
+            }
+        }
+    }
+
     private List<GrammarProduction> getPotentialProductions(String nonTerminal, Grammar grammar) {
         List<GrammarProduction> potentialProduction = new ArrayList<>();
         for (GrammarProduction p : grammar.getProductions()){

--- a/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/word/generation/WordGenerationTest.java
@@ -93,7 +93,7 @@ class WordGenerationTest {
             WordGeneration wordGeneration = new WordGeneration(grammar);
             String word;
             try {
-                word = wordGeneration.generateWordWithParserLimitations(3,10);
+                word = wordGeneration.generateWord(new ParserLimitation(3,10));
                 assertTrue(word.length() <= 3);
             } catch (WordLimitationsNotFulfillableException e) {
                 // Skip not fitting grammars


### PR DESCRIPTION
Nach meinen Untersuchungen habe ich festgestellt, das sich die Anzahl der Gesamtschritte bei Top-down und Bottom-up immer um eins unterscheiden. bei diesem Schritt handelt es sich aber um das hinzufügen des Startsymbols bei Top-down, welches bei Bottom-up am Ende nicht entfernt wird. Das heißt, die tatsächliche Anzahl der Lese und Reduktions bzw. Produktionsschritte ist gleich. Daher habe ich eine Möglichkeit hinzugefügt, mit der Wörter über eine maximale Anzahl an Lese und Aktionsschritten eingeschränkt werden können. Die maximalen Einträge einer Syntaxanalyse ergeben sich bei Top-down aus Leseschritte +  Produktionsschritte +3 und bei Bottom-up aus Leseschritte + Produktionsschritte +2.

Bisher nur ein Test zum Testen der maximalen Leseschritte.

Maximale Wortlänge entspricht der Anzahl der Leseschritte, da für die verschiedenen Aufgabentypen nicht immer Anzahl der Leseschritte verständlich ist, gibt es mal beide Varianten.